### PR TITLE
Make sure tests can run

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ Sadly, you must have a mac to run the iOS emulator.  If you're on a Windows mach
 - Set the simulator on the commandline `$ sudo xcode-select -s /Applications/Xcode.app` (you only need to do this once)
 - Run expo `$ expo start`
 - In the browser window that expo opens, choose "Run on iOS Simulator" from the left sidebar
+
+## Running Tests
+There is a script defined in package.json that allows you to run the tests as follows from the project root:
+
+`$ npm tests`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "eject": "expo eject",
-    "test": "node ./node_modules/jest/bin/jest.js --watchAll"
+    "test": "node node_modules/jest-expo/bin/jest.js --watchAll"
   },
   "jest": {
     "preset": "jest-expo"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "eject": "expo eject",
-    "test": "node ./node_modules/jest-expo/bin/jest.js --watchAll"
+    "test": "node ./node_modules/$npm_package_jest_preset/bin/jest.js --watchAll"
   },
   "jest": {
     "preset": "jest-expo"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "eject": "expo eject",
-    "test": "node node_modules/jest-expo/bin/jest.js --watchAll"
+    "test": "node ./node_modules/jest-expo/bin/jest.js --watchAll"
   },
   "jest": {
     "preset": "jest-expo"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "license": "SEE LICENSE IN LICENSE.MD",
-  "name": "my-new-project",
+  "name": "moneyOnMyMind",
   "main": "node_modules/expo/AppEntry.js",
   "private": true,
   "scripts": {


### PR DESCRIPTION
I tried to run the test suite and it failed initially.  I'm going to see if I can get it running again.

```
$ npm test

> my-new-project@1.0.0 test /Users/micah/sites/cvoeo-app
> node ./node_modules/jest/bin/jest.js --watchAll

module.js:550
    throw err;
    ^

Error: Cannot find module '/Users/micah/sites/cvoeo-app/node_modules/jest/bin/jest.js'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)
    at bootstrap_node.js:625:3
npm ERR! Test failed.  See above for more details.
```

Now when I run `npm test` I get the following result:
![image](https://user-images.githubusercontent.com/1809882/47591934-58c0d680-d93f-11e8-8c7b-6ef89512b203.png)
