### PR TITLE
Added SafeAreaView tag and calculated logo image ratio

### DIFF
--- a/screens/login/login-screen.js
+++ b/screens/login/login-screen.js
@@ -23,8 +23,9 @@ const myStyles = {
 const combinedStyles = Object.assign({}, commonStyles, myStyles);
 const styles = StyleSheet.create(combinedStyles);
 const window = Dimensions.get('window');
-const logoHeight = 342 * (window.width / 287) * 0.89;
-const logoWidth = window.width * 0.89;
+const logoScale = 0.89;
+const logoHeight = 342 * (window.width / 287) * logoScale;
+const logoWidth = window.width * logoScale;
 
 type Props = {
     actions: Object,

--- a/screens/login/login-screen.js
+++ b/screens/login/login-screen.js
@@ -70,7 +70,7 @@ class LoginScreen extends Component<Props> {
             >
                 <View style={styles.container}>
                     <ScrollView style={[styles.scroll, { backgroundColor: '#04a0c6' }]}>
-                        <View style={{ paddingTop: 30, paddingLeft: 20, paddingRight: 20 }}>
+                        <View style={{ paddingTop: 10, paddingLeft: 20, paddingRight: 20 }}>
                             <View style={styles.logo}>
                                 <Image source={logo} style={{ height: logoHeight, width: logoWidth }} />
                             </View>

--- a/screens/login/login-screen.js
+++ b/screens/login/login-screen.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import {
-    Image, KeyboardAvoidingView, ScrollView, StyleSheet, Text, TouchableHighlight, View, Alert,
+    Dimensions, Image, KeyboardAvoidingView, SafeAreaView, ScrollView, StyleSheet, Text, TouchableHighlight, View, Alert,
     Platform
 } from 'react-native';
 // import * as constants from '../../styles/constants';
@@ -22,6 +22,9 @@ const myStyles = {
 };
 const combinedStyles = Object.assign({}, commonStyles, myStyles);
 const styles = StyleSheet.create(combinedStyles);
+const window = Dimensions.get('window');
+const logoHeight = 342 * (window.width / 287) * 0.89;
+const logoWidth = window.width * 0.89;
 
 type Props = {
     actions: Object,
@@ -60,6 +63,7 @@ class LoginScreen extends Component<Props> {
 
     render() {
         return (
+            <SafeAreaView style={{flex: 1, backgroundColor: '#fff'}}>
             <KeyboardAvoidingView
                 style={[styles.frame, { backgroundColor: '#04a0c6' }]}
                 behavior={Platform.OS === 'ios' ? 'padding' : null}
@@ -68,7 +72,7 @@ class LoginScreen extends Component<Props> {
                     <ScrollView style={[styles.scroll, { backgroundColor: '#04a0c6' }]}>
                         <View style={{ paddingTop: 30, paddingLeft: 20, paddingRight: 20 }}>
                             <View style={styles.logo}>
-                                <Image source={logo} style={{ height: 342, width: '100%' }} />
+                                <Image source={logo} style={{ height: logoHeight, width: logoWidth }} />
                             </View>
                             <View style={{ width: '91%', alignSelf: 'center' }}>
                                 <LoginForm onButtonPress={this.props.actions.loginWithEmailPassword} />
@@ -85,6 +89,7 @@ class LoginScreen extends Component<Props> {
                     </ScrollView>
                 </View>
             </KeyboardAvoidingView>
+            </SafeAreaView>
         );
     }
 }


### PR DESCRIPTION
`screens/login/login-screen.js`:

1. SafeAreaView was added to correctly display on iOS.

2. When logo image height was set to 342 (the actual height of the image) and width to 100%, the image was resized correctly, but the top and bottom of the image were cut off.  To calculate height and width correctly, used `Dimensions.get`:

```
const window = Dimensions.get('window');
const logoHeight = 342 * (window.width / 287) * 0.89;
const logoWidth = window.width * 0.89;
```