### PR TITLE
removed extra polygon in the svg clippath causing bug

### DIFF
--- a/screens/dashboard/index.js
+++ b/screens/dashboard/index.js
@@ -210,9 +210,6 @@ class Dashboard extends Component<Props> {
                           height={200}
                           width={200}
                         />
-                        <Svg.Polygon
-                          points="50,50 120,120" />
-
                       </Svg.ClipPath>
                       <Svg.Circle
                         cx={100}


### PR DESCRIPTION
`screens/dashboard/index.js`:

This extra shape seemed to be causing the problem:

```
                        <Svg.Polygon
                          points="50,50 120,120" />
```

After removing it, the speedometer displays correctly on iOS.

