### PR TITLE
Update asset path to allow publishing to expo

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,9 +19,7 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["./assets/"],
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "org.cvoeo.app",


### PR DESCRIPTION
It looks like expo isn't parsing the old wildcard asset path anymore.  
![image](https://user-images.githubusercontent.com/1809882/64135372-b28efa00-cdb5-11e9-9ac6-be522ba8832e.png)

But [this post in their issue queue](https://github.com/expo/expo-cli/issues/753) guided me to this solution and the build seemed to publish just fine.

FYI, publishing a project to your expo account is as simple as `$ expo publish`. 

