### PR TITLE
Minor changes to app.json to match project account on expo

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,12 +1,15 @@
 {
   "expo": {
-    "name": "CVOEO",
+    "name": "MoMM",
     "description": "A Code For America App to help CVOEO's Reach-Up clients stay on track with their personal finance coaching.",
-    "slug": "CVOEO",
+    "slug": "momm",
     "privacy": "public",
     "sdkVersion": "34.0.0",
     "primaryColor": "#FFFFFF",
-    "platforms": ["ios", "android"],
+    "platforms": [
+      "ios",
+      "android"
+    ],
     "githubUrl": "https://github.com/codeforbtv/cvoeo-app",
     "version": "1.0.0",
     "orientation": "portrait",
@@ -19,7 +22,9 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": ["./assets/"],
+    "assetBundlePatterns": [
+      "./assets/"
+    ],
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "org.cvoeo.app",


### PR DESCRIPTION
Now we can publish to this account instead of our persona accounts: https://expo.io/@moneyonmymind/momm

Credentials for the project account are inside the CVOEO team drive folder: https://docs.google.com/spreadsheets/d/1_H0kTsCe-bPAx82IEI7SGFwsL9PhyOa6AVcYTg6HCqo/edit#gid=0