### PR TITLE
Another fix.  Disabling dev deployment for now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,13 @@ workflows:
   version: 2
   my_app:
     jobs:
-      - publish_to_expo_dev:
-          filters:
-            branches:
-              only: master
+#      - publish_to_expo_dev:
+#          filters:
+#            branches:
+#              only: master
       - publish_to_expo_prod:
-          requires:
-            - publish_to_expo_dev
+#          requires:
+#            - publish_to_expo_dev
           filters:
             branches:
               only: master


### PR DESCRIPTION
Dev deployment and prod are conflicting with version number increment.  Disabling dev for now until we move it to another branch.